### PR TITLE
Fix URL for entity repository download

### DIFF
--- a/README.html
+++ b/README.html
@@ -54,7 +54,7 @@
 
 <p>Get the Entity Repository (21 GB):</p>
 
-<pre><code>curl -O http://www.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2010-08-17v7.sql.bz2
+<pre><code>curl -O http://resources.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2010-08-17v7.sql.bz2
 </code></pre>
 
 <p>Import it into a postgres database:</p>
@@ -64,7 +64,7 @@
 
 <p>where <DATABASE> is a database on a PostgreSQL server.</p>
 
-<p>A database dump on a more recent version of Wikipedia is also available: http://www.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2014&#8211;01&#8211;02v7.sql.bz2</p>
+<p>A database dump on a more recent version of Wikipedia is also available: http://resources.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2014&#8211;01&#8211;02v7.sql.bz2</p>
 
 <h2 id="settingupaida">Setting up AIDA</h2>
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use AIDA with YAGO2, download the repository we provide on our [AIDA website]
 
 Get the Entity Repository (21 GB):
 
-    curl -O http://www.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2010-08-17v7.sql.bz2
+    curl -O http://resources.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2010-08-17v7.sql.bz2
     
 Import it into a postgres database:
 
@@ -58,7 +58,7 @@ Import it into a postgres database:
     
 where <DATABASE> is a database on a PostgreSQL server.
 
-A database dump on a more recent version of Wikipedia is also available: http://www.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2014-01-02v7.sql.bz2
+A database dump on a more recent version of Wikipedia is also available: http://resources.mpi-inf.mpg.de/yago-naga/aida/download/entity-repository/AIDA_entity_repository_2014-01-02v7.sql.bz2
 
 ## Setting up AIDA
 


### PR DESCRIPTION
The `www.mpi-inf` URLs are broken.